### PR TITLE
Add TutorialSearch to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ We are a robotics integrator developing technology for autonomous disassembly of
 - [An Introduction to different Types of Convolutions in Deep Learning](https://towardsdatascience.com/types-of-convolutions-in-deep-learning-717013397f4d) - Paul-Louis Prove
 - [TensorFlow Official Tutorials for Beginners and for Experts](https://www.tensorflow.org/tutorials) - TensorFlow
 - [PyTorch Official Tutorials](https://pytorch.org/tutorials/) - PyTorch
+- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ### Books
 - [Deep Learning for Coders with fastai and PyTorch](https://github.com/fastai/fastbook) - fast.ai

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We are a robotics integrator developing technology for autonomous disassembly of
 - [An Introduction to different Types of Convolutions in Deep Learning](https://towardsdatascience.com/types-of-convolutions-in-deep-learning-717013397f4d) - Paul-Louis Prove
 - [TensorFlow Official Tutorials for Beginners and for Experts](https://www.tensorflow.org/tutorials) - TensorFlow
 - [PyTorch Official Tutorials](https://pytorch.org/tutorials/) - PyTorch
-- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+- [TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/artificial-intelligence) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ### Books
 - [Deep Learning for Coders with fastai and PyTorch](https://github.com/fastai/fastbook) - fast.ai


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Tutorials* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/artificial-intelligence) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/artificial-intelligence) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.